### PR TITLE
docs: add README and fix router lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# TanStack Start Event Calendar
+
+A full project for an event calendar built with [TanStack Start](https://tanstack.com/start). It combines [TanStack Router](https://tanstack.com/router) for routing, [Tailwind CSS](https://tailwindcss.com) for styling, and a Prisma-powered backend backed by SQLite.
+
+## Getting Started
+
+1. **Install dependencies**
+
+   ```bash
+   pnpm install
+   ```
+
+2. **Initialize the database**
+
+   Create a `.env` file in the project root with:
+
+   ```env
+   DATABASE_URL="file:./dev.db"
+   ```
+
+   Then run:
+
+   ```bash
+   pnpm prisma db push
+   pnpm prisma db seed
+   ```
+
+3. **Start the development server**
+
+   ```bash
+   pnpm dev
+   ```
+
+4. **Run the linter**
+
+   ```bash
+   pnpm lint
+   ```
+
+## Build
+
+Create an optimized production build:
+
+```bash
+pnpm build
+```
+
+## License
+
+This project is licensed under the ISC License.

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,14 +1,14 @@
 import { createRouter as createTanStackRouter } from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
 
-export function createRouter() {
+export const createRouter = () => {
   const router = createTanStackRouter({
     routeTree,
     scrollRestoration: true,
   });
 
   return router;
-}
+};
 
 declare module "@tanstack/react-router" {
   interface Register {


### PR DESCRIPTION
## Summary
- document project setup and build steps in new README
- resolve ESLint func-style rule by converting `createRouter` to arrow function
- mention tech stack (TanStack Router, Tailwind CSS, Prisma) and add database initialization/seed instructions

## Testing
- `pnpm prisma db push`
- `pnpm prisma db seed`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6890a36a0c508325ae1eae75e87b6595